### PR TITLE
updated the url for spoor, updated the server url and added click tra…

### DIFF
--- a/client/scripts/main.js
+++ b/client/scripts/main.js
@@ -26,7 +26,6 @@ on(".js-search-form", "submit", function (event) {
 
 // Submit the filter form on change
 on(".js-filter-form-select", "change", function (event) {
-  console.log(event);
   if (window.oTracking) {
     const context =
       event.target.value == "_" || !event.target.value

--- a/client/scripts/main.js
+++ b/client/scripts/main.js
@@ -41,7 +41,7 @@ on(".js-filter-form-select", "change", function (event) {
     window.oTracking.event({ detail: eventConfig });
   }
 
-  // document.querySelector(".js-filter-form").submit();
+  document.querySelector(".js-filter-form").submit();
 });
 
 var books_request;

--- a/client/scripts/main.js
+++ b/client/scripts/main.js
@@ -5,34 +5,53 @@ function on(selector, event, callback) {
   document.querySelector(selector).addEventListener(event, callback);
 }
 
-document.querySelector('.js-filter-bar-toggle-placeholder')
-        .insertAdjacentHTML('beforeend', '<a href="#filterbar" class="js-filter-bar-toggle top-bar__action" role="button"><span class="visuallyhidden">Menu</span></a>');
+document
+  .querySelector(".js-filter-bar-toggle-placeholder")
+  .insertAdjacentHTML(
+    "beforeend",
+    '<a href="#filterbar" class="js-filter-bar-toggle top-bar__action" role="button"><span class="visuallyhidden">Menu</span></a>'
+  );
 
-on('.js-filter-bar-toggle', 'click', function(event) {
+on(".js-filter-bar-toggle", "click", function (event) {
   event.preventDefault();
-  var filterBar = document.querySelector('.js-filter-bar');
+  var filterBar = document.querySelector(".js-filter-bar");
   if (!filterBar) return;
-  filterBar.classList.toggle('filter-bar--hidden');
+  filterBar.classList.toggle("filter-bar--hidden");
 });
 
 // Prevent search form submission
-on('.js-search-form', 'submit', function(event) {
+on(".js-search-form", "submit", function (event) {
   event.preventDefault();
 });
 
 // Submit the filter form on change
-on('.js-filter-form-select', 'change', function(event) {
-  document.querySelector('.js-filter-form').submit();
+on(".js-filter-form-select", "change", function (event) {
+  console.log(event);
+  if (window.oTracking) {
+    const context =
+      event.target.value == "_" || !event.target.value
+        ? "all"
+        : event.target.value;
+
+    const eventConfig = {
+      category: "category",
+      action: "select",
+      context: context,
+    };
+    window.oTracking.event({ detail: eventConfig });
+  }
+
+  // document.querySelector(".js-filter-form").submit();
 });
 
 var books_request;
 var Keys = {
   UP_ARROW: 38,
   DOWN_AROW: 40,
-  ENTER: 13
-}
+  ENTER: 13,
+};
 
-on('.js-tipue-drop', 'keydown', function(event) {
+on(".js-tipue-drop", "keydown", function (event) {
   var key_code = event.keyCode;
   var value = event.target.value;
   var open = event.target.is_open;
@@ -59,8 +78,7 @@ on('.js-tipue-drop', 'keydown', function(event) {
   }
 });
 
-on('.js-tipue-drop', 'keyup', function(event) {
-
+on(".js-tipue-drop", "keyup", function (event) {
   var value = event.target.value.trim();
   var key_code = event.keyCode;
   var last_value = event.target.last_value;
@@ -75,41 +93,45 @@ on('.js-tipue-drop', 'keyup', function(event) {
     return;
   }
 
-  if(!value) {
+  if (!value) {
     hide_results();
     return;
   }
 
   if (!books_request) {
-    books_request = fetch(window.searchOptions.contentLocation).then(function(response){
+    books_request = fetch(window.searchOptions.contentLocation).then(function (
+      response
+    ) {
       return response.json();
     });
   }
 
-  books_request.then(function(books){
-    var search_results = search(value, books)
+  books_request.then(function (books) {
+    var search_results = search(value, books);
     view_search_results(search_results);
   });
-
 });
 
 function filter_book_fuzzy(value) {
-  var pat = new RegExp(value, 'i');
-  return function(book) {
-    return book.title.search(pat) !== -1 ||
-            book.author.search(pat) !== -1 ||
-            book.year.toString().search(pat) !== -1;
-  }
+  var pat = new RegExp(value, "i");
+  return function (book) {
+    return (
+      book.title.search(pat) !== -1 ||
+      book.author.search(pat) !== -1 ||
+      book.year.toString().search(pat) !== -1
+    );
+  };
 }
 
 function filter_book_exact_title(value) {
   value = value.toLowerCase();
-  return function(book) {
-    var s = book.title.toLowerCase()
-                      .replace(/^(a|the) /, '')
-                      .indexOf(value);
+  return function (book) {
+    var s = book.title
+      .toLowerCase()
+      .replace(/^(a|the) /, "")
+      .indexOf(value);
     return s === 0;
-  }
+  };
 }
 
 function search(query, books) {
@@ -122,98 +144,124 @@ function search(query, books) {
   return books.filter(filter_book_fuzzy(query)).slice(0, 3);
 }
 
-function  go_to_selected() {
-  var selected = document.querySelector('.tipue_drop_item.selected');
+function go_to_selected() {
+  var selected = document.querySelector(".tipue_drop_item.selected");
   if (!selected) return;
   selected.click();
   hide_results();
 }
 
 function select_previous() {
-  var selected = document.querySelector('.tipue_drop_item.selected');
-  if (selected && selected.previousElementSibling && selected.previousElementSibling.classList.contains('tipue_drop_item')) {
-    selected.classList.remove('selected');
-    selected.previousElementSibling.classList.add('selected');
-    if (typeof selected.previousElementSibling.scrollIntoViewIfNeeded === 'function') {
+  var selected = document.querySelector(".tipue_drop_item.selected");
+  if (
+    selected &&
+    selected.previousElementSibling &&
+    selected.previousElementSibling.classList.contains("tipue_drop_item")
+  ) {
+    selected.classList.remove("selected");
+    selected.previousElementSibling.classList.add("selected");
+    if (
+      typeof selected.previousElementSibling.scrollIntoViewIfNeeded ===
+      "function"
+    ) {
       selected.previousElementSibling.scrollIntoViewIfNeeded(false);
     }
   } else {
-    var input = document.querySelector('.js-tipue-drop');
-    if (input && typeof input.scrollIntoViewIfNeeded === 'function') {
+    var input = document.querySelector(".js-tipue-drop");
+    if (input && typeof input.scrollIntoViewIfNeeded === "function") {
       input.scrollIntoViewIfNeeded(false);
     }
   }
 }
 
 function select_next() {
-  var selected = document.querySelector('.tipue_drop_item.selected');
+  var selected = document.querySelector(".tipue_drop_item.selected");
   var next;
 
-  if (selected && selected.nextElementSibling && selected.nextElementSibling.classList.contains('tipue_drop_item')) {
+  if (
+    selected &&
+    selected.nextElementSibling &&
+    selected.nextElementSibling.classList.contains("tipue_drop_item")
+  ) {
     next = selected.nextElementSibling;
   } else {
-    next = document.querySelector('.tipue_drop_item');
+    next = document.querySelector(".tipue_drop_item");
   }
 
   if (selected && next) {
-    selected.classList.remove('selected');
+    selected.classList.remove("selected");
   }
 
   if (next) {
-    next.classList.add('selected');
-    if (typeof next.scrollIntoViewIfNeeded === 'function') {
+    next.classList.add("selected");
+    if (typeof next.scrollIntoViewIfNeeded === "function") {
       next.scrollIntoViewIfNeeded(false);
     }
   }
 }
 
 function hide_results() {
-  var dropdown = document.getElementById('tipue_drop_content');
+  var dropdown = document.getElementById("tipue_drop_content");
   // hide popup - fade out with speed variable
-  dropdown.classList.remove('tipue_drop_show');
+  dropdown.classList.remove("tipue_drop_show");
 
-  var selected = document.querySelector('.tipue_drop_item.selected');
+  var selected = document.querySelector(".tipue_drop_item.selected");
 
   if (selected) {
-    selected.classList.remove('selected');
+    selected.classList.remove("selected");
   }
 
-  document.removeEventListener('click', hide_results);
+  document.removeEventListener("click", hide_results);
 }
 
 function show_results(html) {
-  var dropdown = document.getElementById('tipue_drop_content');
+  var dropdown = document.getElementById("tipue_drop_content");
 
-  if (typeof html === 'string') {
+  if (typeof html === "string") {
     dropdown.innerHTML = html;
   }
 
-  dropdown.classList.add('tipue_drop_show');
-  document.addEventListener('click', hide_results);
+  dropdown.classList.add("tipue_drop_show");
+  document.addEventListener("click", hide_results);
 }
 
 function view_search_results(search_results) {
-
   if (!search_results.length) {
     hide_results();
-    return
+    return;
   }
 
   var route = window.searchOptions.route;
-  var html = '';
+  var html = "";
 
-  html += '<div id="tipue_drop_wrapper"><div class="tipue_drop_head"><div id="tipue_drop_head_text">Suggested results</div></div>';
-  html += search_results.map(function(book) {
-    var out = '';
-    out += '<a class="tipue_drop_item" href="' + route(book) + '"';
-    out += '><div ><div class="tipue_drop_left">';
-    out += '<img src="http://image.webservices.ft.com/v1/images/raw/' + book.cover;
-    out += '?source=ft_ig_business_book_award_search&amp;width=120" class="tipue_drop_image" alt=""></div>';
-    out += '<div class="tipue_drop_right"><div class="tipue_drop_right_title">' + book.title + '</div>';
-    out += '<div class="tipue_drop_right_text">' + book.author + '<br />' + book.year + '</div></div></div></a>';
-    return out;
-  }).join('');
-  html += '</div>';
+  html +=
+    '<div id="tipue_drop_wrapper"><div class="tipue_drop_head"><div id="tipue_drop_head_text">Suggested results</div></div>';
+  html += search_results
+    .map(function (book) {
+      var out = "";
+      out +=
+        '<a class="tipue_drop_item" data-trackable="search-results" href="' +
+        route(book) +
+        '"';
+      out += '><div ><div class="tipue_drop_left">';
+      out +=
+        '<img src="http://image.webservices.ft.com/v1/images/raw/' + book.cover;
+      out +=
+        '?source=ft_ig_business_book_award_search&amp;width=120" class="tipue_drop_image" alt=""></div>';
+      out +=
+        '<div class="tipue_drop_right"><div class="tipue_drop_right_title">' +
+        book.title +
+        "</div>";
+      out +=
+        '<div class="tipue_drop_right_text">' +
+        book.author +
+        "<br />" +
+        book.year +
+        "</div></div></div></a>";
+      return out;
+    })
+    .join("");
+  html += "</div>";
 
   show_results(html);
 }

--- a/views/layout.html
+++ b/views/layout.html
@@ -86,7 +86,7 @@
                     </label>
                     <input type="text" class="o-forms-text search-form__field js-tipue-drop" autocomplete="off" id="tipue_drop_input" placeholder="Search for a book title or author" value="" data-trackable="search-box" />
                     <label type="submit" value="Submit" class="search-form__submit" tabindex="-1" for="tipue_drop_input" ></label>
-                    <div id="tipue_drop_content" data-trackable="search-results"></div>
+                    <div id="tipue_drop_content" ></div>
                 </div>
             </form>
             <form class="filter-form js-filter-form" action="{{ router.url('home') }}" method="get">
@@ -196,6 +196,33 @@
         </script>
 
         {# FT Tracking module (Spoor) #}
-        <script>(function(){function init(){var oTracking=Origami['o-tracking'];oTracking.init({server:'https://spoor-api.ft.com/ingest',system:{is_live:true},context:{product:'IG'}});oTracking.click.init('cta');oTracking.page({content:{asset_type:'interactive',microsite_name: 'BBYA'}});}var o=document.createElement('script');o.async=o.defer=true;o.src='https://origami-build.ft.com/v3/bundles/js?components=o-tracking@4.3.0&system_code=business-books-of-the-year';var s=document.getElementsByTagName('script')[0];if(o.hasOwnProperty('onreadystatechange')){o.onreadystatechange=function(){if(o.readyState==='loaded'){init();}};}else{o.onload=init;}s.parentNode.insertBefore(o,s);}());</script><noscript data-o-component="o-tracking"><img src="https://spoor-api.ft.com/px.gif?data=%7B%22action%22%3A%22view%22%2C%22category%22%3A%22page%22%2C%22context%22%3A%7B%22content%22%3A%7B%22asset_type%22%3A%22interactive%22%7D%2C%22product%22%3A%22IG%22%2C%22microsite_name%22%3A%22BBYA%22%7D%2C%22system%22%3A%7B%22is_live%22%3Atrue%2C%22apiKey%22%3A%22qUb9maKfKbtpRsdp0p2J7uWxRPGJEP%22%2C%22source%22%3A%22o-tracking-ns%22%2C%22version%22%3A%221.0.0%22%7D%7D" height="1" width="1" /></noscript>
+        <script> 
+            (function(){
+                function init(){
+                    var oTracking=Origami['o-tracking'];
+                    oTracking.init({server:'https://spoor-api.ft.com/ingest',system:{is_live:true},context:{product:'IG'}});
+                    oTracking.click.init('cta');
+                    oTracking.page({content:{asset_type:'interactive',microsite_name: 'BBYA'}});
+                    window.oTracking = oTracking; 
+                }
+                var o=document.createElement('script');
+                o.async=o.defer=true;
+                o.src='https://origami-build.ft.com/v3/bundles/js?components=o-tracking@4.3.0&system_code=business-books-of-the-year';
+                var s=document.getElementsByTagName('script')[0];
+                if(o.hasOwnProperty('onreadystatechange')){
+                    o.onreadystatechange=function(){
+                        if(o.readyState==='loaded'){
+                            init();
+                        }
+                    };
+                }else{
+                    o.onload=init;
+                }
+                s.parentNode.insertBefore(o,s);
+            }());
+        </script>
+        <noscript data-o-component="o-tracking">
+            <img src="https://spoor-api.ft.com/px.gif?data=%7B%22action%22%3A%22view%22%2C%22category%22%3A%22page%22%2C%22context%22%3A%7B%22content%22%3A%7B%22asset_type%22%3A%22interactive%22%7D%2C%22product%22%3A%22IG%22%2C%22microsite_name%22%3A%22BBYA%22%7D%2C%22system%22%3A%7B%22is_live%22%3Atrue%2C%22apiKey%22%3A%22qUb9maKfKbtpRsdp0p2J7uWxRPGJEP%22%2C%22source%22%3A%22o-tracking-ns%22%2C%22version%22%3A%221.0.0%22%7D%7D" height="1" width="1" />
+        </noscript> 
     </body>
 </html>

--- a/views/layout.html
+++ b/views/layout.html
@@ -79,8 +79,8 @@
         </header>
 
         <div class="filter-bar filter-bar--hidden clearfix js-filter-bar" id="filterbar">
-            <form class="search-form js-search-form">
-                <div class="search-form__inner">
+            <form class="search-form js-search-form" data-trackable="search-form">
+                <div class="search-form__inner" data-trackable="search-form-inner">
                     <label for="tipue_drop_input" class="visuallyhidden">
                         Search for a book title or author
                     </label>
@@ -94,7 +94,7 @@
                     <label for="filter" class="filter-form__label text-quiet text-uppercase text-small" >
                         Category
                     </label>
-                    <select name="category" id="filter" class="filter-form__select o-forms-select js-filter-form-select">
+                    <select name="category" id="filter" class="filter-form__select o-forms-select js-filter-form-select" data-trackable="category-dropdown">
                         {% if book.slug %}
                         <option style="display:none;visibility:hidden;" value="_" selected>Show all</option>
                         {% endif %}
@@ -196,6 +196,6 @@
         </script>
 
         {# FT Tracking module (Spoor) #}
-        <script>(function(){function init(){var oTracking=Origami['o-tracking'];oTracking.init({server:'https://spoor-api.ft.com/ingest',system:{is_live:true},context:{product:'IG'}});oTracking.link.init();oTracking.click.init();oTracking.page({content:{asset_type:'interactive',microsite_name: 'BBYA'}});}var o=document.createElement('script');o.async=o.defer=true;o.src='https://origami-build.ft.com/v3/bundles/js?components=o-tracking@4.3.0&system_code=business-books-of-the-year';var s=document.getElementsByTagName('script')[0];if(o.hasOwnProperty('onreadystatechange')){o.onreadystatechange=function(){if(o.readyState==='loaded'){init();}};}else{o.onload=init;}s.parentNode.insertBefore(o,s);}());</script><noscript data-o-component="o-tracking"><img src="https://spoor-api.ft.com/px.gif?data=%7B%22action%22%3A%22view%22%2C%22category%22%3A%22page%22%2C%22context%22%3A%7B%22content%22%3A%7B%22asset_type%22%3A%22interactive%22%7D%2C%22product%22%3A%22IG%22%2C%22microsite_name%22%3A%22BBYA%22%7D%2C%22system%22%3A%7B%22is_live%22%3Atrue%2C%22apiKey%22%3A%22qUb9maKfKbtpRsdp0p2J7uWxRPGJEP%22%2C%22source%22%3A%22o-tracking-ns%22%2C%22version%22%3A%221.0.0%22%7D%7D" height="1" width="1" /></noscript>
+        <script>(function(){function init(){var oTracking=Origami['o-tracking'];oTracking.init({server:'https://spoor-api.ft.com/ingest',system:{is_live:true},context:{product:'IG'}});oTracking.click.init();oTracking.page({content:{asset_type:'interactive',microsite_name: 'BBYA'}});}var o=document.createElement('script');o.async=o.defer=true;o.src='https://origami-build.ft.com/v3/bundles/js?components=o-tracking@4.3.0&system_code=business-books-of-the-year';var s=document.getElementsByTagName('script')[0];if(o.hasOwnProperty('onreadystatechange')){o.onreadystatechange=function(){if(o.readyState==='loaded'){init();}};}else{o.onload=init;}s.parentNode.insertBefore(o,s);}());</script><noscript data-o-component="o-tracking"><img src="https://spoor-api.ft.com/px.gif?data=%7B%22action%22%3A%22view%22%2C%22category%22%3A%22page%22%2C%22context%22%3A%7B%22content%22%3A%7B%22asset_type%22%3A%22interactive%22%7D%2C%22product%22%3A%22IG%22%2C%22microsite_name%22%3A%22BBYA%22%7D%2C%22system%22%3A%7B%22is_live%22%3Atrue%2C%22apiKey%22%3A%22qUb9maKfKbtpRsdp0p2J7uWxRPGJEP%22%2C%22source%22%3A%22o-tracking-ns%22%2C%22version%22%3A%221.0.0%22%7D%7D" height="1" width="1" /></noscript>
     </body>
 </html>

--- a/views/layout.html
+++ b/views/layout.html
@@ -94,7 +94,7 @@
                     <label for="filter" class="filter-form__label text-quiet text-uppercase text-small" >
                         Category
                     </label>
-                    <select name="category" id="filter" class="filter-form__select o-forms-select js-filter-form-select" data-trackable="category-dropdown">
+                    <select name="category" id="filter" class="filter-form__select o-forms-select js-filter-form-select" >
                         {% if book.slug %}
                         <option style="display:none;visibility:hidden;" value="_" selected>Show all</option>
                         {% endif %}

--- a/views/layout.html
+++ b/views/layout.html
@@ -79,14 +79,14 @@
         </header>
 
         <div class="filter-bar filter-bar--hidden clearfix js-filter-bar" id="filterbar">
-            <form class="search-form js-search-form" data-trackable="search-form">
-                <div class="search-form__inner" data-trackable="search-form-inner">
-                    <label for="tipue_drop_input" class="visuallyhidden">
+            <form class="search-form js-search-form" >
+                <div class="search-form__inner">
+                    <label for="tipue_drop_input" class="visuallyhidden" >
                         Search for a book title or author
                     </label>
-                    <input type="text" class="o-forms-text search-form__field js-tipue-drop" autocomplete="off" id="tipue_drop_input" placeholder="Search for a book title or author" value="" />
-                    <label type="submit" value="Submit" class="search-form__submit" tabindex="-1" for="tipue_drop_input"></label>
-                    <div id="tipue_drop_content"></div>
+                    <input type="text" class="o-forms-text search-form__field js-tipue-drop" autocomplete="off" id="tipue_drop_input" placeholder="Search for a book title or author" value="" data-trackable="search-box" />
+                    <label type="submit" value="Submit" class="search-form__submit" tabindex="-1" for="tipue_drop_input" ></label>
+                    <div id="tipue_drop_content" data-trackable="search-results"></div>
                 </div>
             </form>
             <form class="filter-form js-filter-form" action="{{ router.url('home') }}" method="get">
@@ -196,6 +196,6 @@
         </script>
 
         {# FT Tracking module (Spoor) #}
-        <script>(function(){function init(){var oTracking=Origami['o-tracking'];oTracking.init({server:'https://spoor-api.ft.com/ingest',system:{is_live:true},context:{product:'IG'}});oTracking.click.init();oTracking.page({content:{asset_type:'interactive',microsite_name: 'BBYA'}});}var o=document.createElement('script');o.async=o.defer=true;o.src='https://origami-build.ft.com/v3/bundles/js?components=o-tracking@4.3.0&system_code=business-books-of-the-year';var s=document.getElementsByTagName('script')[0];if(o.hasOwnProperty('onreadystatechange')){o.onreadystatechange=function(){if(o.readyState==='loaded'){init();}};}else{o.onload=init;}s.parentNode.insertBefore(o,s);}());</script><noscript data-o-component="o-tracking"><img src="https://spoor-api.ft.com/px.gif?data=%7B%22action%22%3A%22view%22%2C%22category%22%3A%22page%22%2C%22context%22%3A%7B%22content%22%3A%7B%22asset_type%22%3A%22interactive%22%7D%2C%22product%22%3A%22IG%22%2C%22microsite_name%22%3A%22BBYA%22%7D%2C%22system%22%3A%7B%22is_live%22%3Atrue%2C%22apiKey%22%3A%22qUb9maKfKbtpRsdp0p2J7uWxRPGJEP%22%2C%22source%22%3A%22o-tracking-ns%22%2C%22version%22%3A%221.0.0%22%7D%7D" height="1" width="1" /></noscript>
+        <script>(function(){function init(){var oTracking=Origami['o-tracking'];oTracking.init({server:'https://spoor-api.ft.com/ingest',system:{is_live:true},context:{product:'IG'}});oTracking.click.init('cta');oTracking.page({content:{asset_type:'interactive',microsite_name: 'BBYA'}});}var o=document.createElement('script');o.async=o.defer=true;o.src='https://origami-build.ft.com/v3/bundles/js?components=o-tracking@4.3.0&system_code=business-books-of-the-year';var s=document.getElementsByTagName('script')[0];if(o.hasOwnProperty('onreadystatechange')){o.onreadystatechange=function(){if(o.readyState==='loaded'){init();}};}else{o.onload=init;}s.parentNode.insertBefore(o,s);}());</script><noscript data-o-component="o-tracking"><img src="https://spoor-api.ft.com/px.gif?data=%7B%22action%22%3A%22view%22%2C%22category%22%3A%22page%22%2C%22context%22%3A%7B%22content%22%3A%7B%22asset_type%22%3A%22interactive%22%7D%2C%22product%22%3A%22IG%22%2C%22microsite_name%22%3A%22BBYA%22%7D%2C%22system%22%3A%7B%22is_live%22%3Atrue%2C%22apiKey%22%3A%22qUb9maKfKbtpRsdp0p2J7uWxRPGJEP%22%2C%22source%22%3A%22o-tracking-ns%22%2C%22version%22%3A%221.0.0%22%7D%7D" height="1" width="1" /></noscript>
     </body>
 </html>

--- a/views/layout.html
+++ b/views/layout.html
@@ -91,7 +91,7 @@
             </form>
             <form class="filter-form js-filter-form" action="{{ router.url('home') }}" method="get">
                 <div class="filter-form__inner clearfix">
-                    <label for="filter" class="filter-form__label text-quiet text-uppercase text-small">
+                    <label for="filter" class="filter-form__label text-quiet text-uppercase text-small" >
                         Category
                     </label>
                     <select name="category" id="filter" class="filter-form__select o-forms-select js-filter-form-select">
@@ -196,6 +196,6 @@
         </script>
 
         {# FT Tracking module (Spoor) #}
-        <script>(function(){function init(){var oTracking=Origami['o-tracking'];oTracking.init({server:'https://spoor-api.ft.com/px.gif',system:{is_live:true},context:{product:'IG'}});oTracking.link.init();oTracking.page({content:{asset_type:'interactive',microsite_name: 'BBYA'}});}var o=document.createElement('script');o.async=o.defer=true;o.src='https://origami-build.ft.com/v2/bundles/js?modules=o-tracking';var s=document.getElementsByTagName('script')[0];if(o.hasOwnProperty('onreadystatechange')){o.onreadystatechange=function(){if(o.readyState==='loaded'){init();}};}else{o.onload=init;}s.parentNode.insertBefore(o,s);}());</script><noscript data-o-component="o-tracking"><img src="https://spoor-api.ft.com/px.gif?data=%7B%22action%22%3A%22view%22%2C%22category%22%3A%22page%22%2C%22context%22%3A%7B%22content%22%3A%7B%22asset_type%22%3A%22interactive%22%7D%2C%22product%22%3A%22IG%22%2C%22microsite_name%22%3A%22BBYA%22%7D%2C%22system%22%3A%7B%22is_live%22%3Atrue%2C%22apiKey%22%3A%22qUb9maKfKbtpRsdp0p2J7uWxRPGJEP%22%2C%22source%22%3A%22o-tracking-ns%22%2C%22version%22%3A%221.0.0%22%7D%7D" height="1" width="1" /></noscript>
+        <script>(function(){function init(){var oTracking=Origami['o-tracking'];oTracking.init({server:'https://spoor-api.ft.com/ingest',system:{is_live:true},context:{product:'IG'}});oTracking.link.init();oTracking.click.init();oTracking.page({content:{asset_type:'interactive',microsite_name: 'BBYA'}});}var o=document.createElement('script');o.async=o.defer=true;o.src='https://origami-build.ft.com/v3/bundles/js?components=o-tracking@4.3.0&system_code=business-books-of-the-year';var s=document.getElementsByTagName('script')[0];if(o.hasOwnProperty('onreadystatechange')){o.onreadystatechange=function(){if(o.readyState==='loaded'){init();}};}else{o.onload=init;}s.parentNode.insertBefore(o,s);}());</script><noscript data-o-component="o-tracking"><img src="https://spoor-api.ft.com/px.gif?data=%7B%22action%22%3A%22view%22%2C%22category%22%3A%22page%22%2C%22context%22%3A%7B%22content%22%3A%7B%22asset_type%22%3A%22interactive%22%7D%2C%22product%22%3A%22IG%22%2C%22microsite_name%22%3A%22BBYA%22%7D%2C%22system%22%3A%7B%22is_live%22%3Atrue%2C%22apiKey%22%3A%22qUb9maKfKbtpRsdp0p2J7uWxRPGJEP%22%2C%22source%22%3A%22o-tracking-ns%22%2C%22version%22%3A%221.0.0%22%7D%7D" height="1" width="1" /></noscript>
     </body>
 </html>


### PR DESCRIPTION
- Migrated spoor tracking from version 2 to version 3 
- Updated the tracking with JS server from 'https://spoor-api.ft.com/px.gif'  to  'https://spoor-api.ft.com/ingest'  as this seems to resemble what is currently being used on FT.com. The server for tracking without JS seems to still be 'https://spoor-api.ft.com/px.gif' based off the documentation. 
- I added click events to the tracking but I didn't specify any category in the oTracking.click.init() as I wanted all click events to be tracked. Previously there were link tracking, which I left in to be safe but per migration should be updated. 
- Left the fall back url for if no JS was running untouched.  
- Added data trackable elements to the search bar and category dropdown to be able to distinguish click events.  

Issue: #43 