### PR TITLE
Fix otracking to always include content property in context

### DIFF
--- a/views/layout.html
+++ b/views/layout.html
@@ -284,9 +284,9 @@
             (function(){
                 function init(){
                     var oTracking=Origami['o-tracking'];
-                    oTracking.init({server:'https://spoor-api.ft.com/ingest',system:{is_live:true},context:{product:'IG'}});
+                    oTracking.init({server:'https://spoor-api.ft.com/ingest',system:{is_live:true},context:{product:'IG', content:{asset_type:'interactive',microsite_name: 'BBYA'}}});
                     oTracking.click.init('cta');
-                    oTracking.page({content:{asset_type:'interactive',microsite_name: 'BBYA'}});
+                    oTracking.page();
                     window.oTracking = oTracking; 
                 }
                 var o=document.createElement('script');


### PR DESCRIPTION
Currently on https://ig.ft.com/sites/business-book-award only the page view events have the microsite name and asset_type specified. This PR should add those to click events, category changes, search box entry and scroll depth (plus any other analytics we decide to add at a later date).