### PR TITLE
Remove polyfill.io

### DIFF
--- a/views/layout.html
+++ b/views/layout.html
@@ -59,7 +59,6 @@
         <!--[if lte IE 8]>
         <link rel="stylesheet" type="text/css" href="{{ asset('styles/oldie.css') }}">
         <![endif]-->
-        <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
     </head>
     <body itemscope itemtype="https://schema.org/WebPage">
 


### PR DESCRIPTION
Due to ownership of polyfill.io to an untrusted third party, we're moving to a new Fastly hosted version across our sites. However it didn't look like polyfill.io was actually being used here to pull in any features so am removing completely.