### PR TITLE
SI-85 Hako AWS Migration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,14 @@
+version: 2.1
+
+jobs:
+  hello-job:
+    docker:
+      - image: cimg/node:17.2.0 # the primary container, where your job's commands are run
+    steps:
+      - checkout # check out the code in the project directory
+      - run: echo "hello world" # run the `echo` command
+
+workflows:
+  my-workflow:
+    jobs:
+      - hello-job

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+.toolkitstate
+**/.gitignore
+**/node_modules
+**/test
+coverage
+Dockerfile
+LICENSE
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:18-alpine
+
+WORKDIR /app
+RUN chown node:node /app
+
+USER node
+
+COPY --chown=node:node package*.json ./
+RUN npm ci --omit=dev --ignore-scripts
+
+COPY --chown=node:node . ./
+
+CMD ["node", "--harmony", "./app.js"]
+

--- a/hako-config/apps/business-books-of-the-year/story-finding-dev/app.yaml
+++ b/hako-config/apps/business-books-of-the-year/story-finding-dev/app.yaml
@@ -1,0 +1,18 @@
+application: business-books-of-the-year
+environment: story-finding-dev
+
+stacks:
+  web:
+    type: public-load-balanced-web-service
+    parameters:
+      TaskCount: 1
+      TaskCpu: 256
+      TaskCpuArchitecture: ARM64
+      TaskMemory: 512
+      ContainerRegistry: docker.packages.ft.com/container-workshop-2024
+      ContainerRegistryCredentialsSecretName: /hako/registry-credential/cloudsmith/filip-hristov
+      ContainerGoodToGoEndpoint: /__gtg
+
+tags:
+  systemCode: business-books-of-the-year
+  environment: d


### PR DESCRIPTION
Initial code for migrating to hako container deployment in AWS. Adding placeholder hako-config, to be adjusted. Adding Dockerfile for containarizing the application. Adding circleci placeholder config for preparing the ci pipeline to deploy the app with hako.